### PR TITLE
Add CO2e to job

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Jobs/electricitymaps-scraper"]
+	path = Jobs/electricitymaps-scraper
+	url = https://gitlab.cern.ch/bbrueers/electricitymaps-scraper

--- a/Jobs/job_indexer.py
+++ b/Jobs/job_indexer.py
@@ -221,6 +221,8 @@ for row in cursor:
     ## co2e per kWh and site
     doc["co2e"] = siteToCO2eMap[ doc["computingsite"] ] * 1000 * doc["cpuconsumptiontime"] / 3600.           * 12.0
     #                co2e/kWh (converted to Wh )               * time (in seconds --> divide by 3600 for h)  * watts/core (average value type "Any" from https://github.com/GreenAlgorithms/green-algorithms-tool/blob/master/data/v2.1/TDP_cpu.csv)
+    #To-do: - make dependent on start-/endtime?
+    #       - take different CPUs into account
 
     for parser in parsers:
         doc.update(parser.parse(doc[parser.source]))


### PR DESCRIPTION
Adds a basic version of a CO2e calculation per job.

Adds the elasticsearch reader as a submodule. 

Currently, the CO2e is calculated by
(cumulative sum of CPU core usage time) * (co2e/kWh of the site at the execution time of the script) * (an average Watts per core)

This is to be refined using the starttime and endtime, as well as more granular co2e/kWh per site numbers. Furthermore the Watts/per core is to be adjusted to the cores used.